### PR TITLE
Optimized random delay in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,7 @@ jobs:
 
         # Random delay to work around the 500 errors
       - name: Random Delay
-        run: |
-          HASH=$(cksum <<< '${{ matrix.host }}' | cut -f 1 -d ' ')
-          sleep $(($HASH % 30))
+        run: sleep $((${{ strategy.job-index }} * 5))
 
       - name: Pulumi login
         uses: pulumi/auth-actions@v1


### PR DESCRIPTION
Replaced the previous method of generating a random delay in the continuous integration workflow with a simpler approach. The new method uses the job index multiplied by 5 to create a delay, reducing complexity and potential errors.
