### PR TITLE
Update workflow to rely on the env set by the auth action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
           refresh: true
           pulumi-version-file: .versions/pulumi
           # expect-no-changes: ${{ github.actor == 'renovate[bot]' }}
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        # env:
+        #   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Re https://github.com/pulumi/auth-actions/issues/34#event-15255542273

The auth action automatically dump the pulumi access token in the job environment so it shouldn't be necessary to explicitly load it.