### PR TITLE
feat: move castor to the homelab VLAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There is no status field; filter downstream if you only want a subset.
 | zeus | 192.168.1.10 | amd64 | basement, k8s, worker, tower, server |
 | gaea | 192.168.1.11 | amd64 | basement, k8s, worker, rack, server |
 | apollo | 192.168.1.12 | amd64 | basement, k8s, worker, rack, server, headless |
-| castor | 192.168.1.13 | amd64 | basement, k8s, worker, rack, server, headless |
+| castor | 10.0.69.13 | amd64 | basement, k8s, worker, rack, server, headless |
 | pollux | 10.0.69.14 | amd64 | basement, k8s, worker, rack, server, headless |
 | vrk8s1 | 192.168.1.107 | amd64 | living-room, tower, k8s, worker, server, headless, vr, gaming, tv, media |
 | pik8s0a | 192.168.1.114 | arm64 | pi4b, k8s, worker, server, headless, portable |

--- a/hosts.nix
+++ b/hosts.nix
@@ -71,7 +71,7 @@
   };
 
   castor = {
-    ip = "192.168.1.13";
+    ip = "10.0.69.13";
     arch = "amd64";
     tags = [
       "basement"


### PR DESCRIPTION
castor joins rosequartz as a worker, and the cluster lives on VLAN 20, so its address moves from `192.168.1.13` to `10.0.69.13`. The last octet is kept, the way pollux kept `.14` across the same move.

Tags are unchanged: `basement, k8s, worker, rack, server, headless`, already identical to pollux's.

`nix eval .#lib.errors --json` returns `[]` and `make check` passes. `README.md`'s host table is updated alongside, since nothing generates it.

Consumed downstream by UnstoppableMango/nixos, which needs `nix flake update hosts` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)